### PR TITLE
updated sharp version for node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/RealImage/concave#readme",
   "dependencies": {
     "aws-sdk": "^2.69.0",
-    "sharp": "^0.23.4"
+    "sharp": "^0.32.6"
   }
 }


### PR DESCRIPTION
For lambda function , we have updated node version to 16.x. To support the same sharp version has been updated to '0.32.6'